### PR TITLE
Make sixpack.Session take an object of options instead of args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ session.participate("test-exp", ["alt-one", "alt-two"], function (err, res) {
 When instantiating the session object you can pass optional params `client_id`, `base_url`, `ip_address`, `user_agent`
 
 ```js
-var sixpack = new sixpack.Session(12345, 'http://google.com/sixpack', '1.2.2.1', 'ChromeBot');
+var sixpack = new sixpack.Session({client_id: 12345, base_url: 'http://google.com/sixpack', ip_address: '1.2.2.1', user_agent: 'ChromeBot'});
 ```
 
 Client ID is a previously generated client id that you've previously stored. IP Address and User Agent are used for bot detection.

--- a/sixpack.js
+++ b/sixpack.js
@@ -1,4 +1,8 @@
 (function () {
+
+    // Object.assign polyfill from https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+    Object.assign||Object.defineProperty(Object,"assign",{enumerable:!1,configurable:!0,writable:!0,value:function(e){"use strict";if(void 0===e||null===e)throw new TypeError("Cannot convert first argument to object");for(var r=Object(e),t=1;t<arguments.length;t++){var n=arguments[t];if(void 0!==n&&null!==n){n=Object(n);for(var o=Object.keys(Object(n)),a=0,c=o.length;c>a;a++){var i=o[a],b=Object.getOwnPropertyDescriptor(n,i);void 0!==b&&b.enumerable&&(r[i]=n[i])}}}return r}});
+
     var sixpack = {base_url: "http://localhost:5000", ip_address: null, user_agent: null, timeout: 1000};
 
     // check for node module loader
@@ -19,15 +23,13 @@
     };
 
     sixpack.Session = function (options) {
-        options = options || {};
-        this.client_id = options.client_id || sixpack.generate_client_id();
-        this.base_url = options.base_url || sixpack.base_url;
-        this.ip_address = options.ip_addess || sixpack.ip_address;
-        this.user_agent = options.user_agent || sixpack.user_agent;
+        Object.assign(this, sixpack, options);
+        if(!this.client_id) {
+          this.client_id = this.generate_client_id();
+        }
         if (!on_node) {
             this.user_agent = this.user_agent || (window && window.navigator && window.navigator.userAgent);
         }
-        this.timeout = options.timeout || sixpack.timeout;
     };
 
     sixpack.Session.prototype = {

--- a/sixpack.js
+++ b/sixpack.js
@@ -18,15 +18,16 @@
         });
     };
 
-    sixpack.Session = function (client_id, base_url, ip_address, user_agent, timeout) {
-        this.client_id = client_id || sixpack.generate_client_id();
-        this.base_url = base_url || sixpack.base_url;
-        this.ip_address = ip_address || sixpack.ip_address;
-        this.user_agent = user_agent || sixpack.user_agent;
+    sixpack.Session = function (options) {
+        options = options || {};
+        this.client_id = options.client_id || sixpack.generate_client_id();
+        this.base_url = options.base_url || sixpack.base_url;
+        this.ip_address = options.ip_addess || sixpack.ip_address;
+        this.user_agent = options.user_agent || sixpack.user_agent;
         if (!on_node) {
             this.user_agent = this.user_agent || (window && window.navigator && window.navigator.userAgent);
         }
-        this.timeout = timeout || sixpack.timeout;
+        this.timeout = options.timeout || sixpack.timeout;
     };
 
     sixpack.Session.prototype = {

--- a/sixpack.js
+++ b/sixpack.js
@@ -1,5 +1,4 @@
 (function () {
-
     // Object.assign polyfill from https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
     Object.assign||Object.defineProperty(Object,"assign",{enumerable:!1,configurable:!0,writable:!0,value:function(e){"use strict";if(void 0===e||null===e)throw new TypeError("Cannot convert first argument to object");for(var r=Object(e),t=1;t<arguments.length;t++){var n=arguments[t];if(void 0!==n&&null!==n){n=Object(n);for(var o=Object.keys(Object(n)),a=0,c=o.length;c>a;a++){var i=o[a],b=Object.getOwnPropertyDescriptor(n,i);void 0!==b&&b.enumerable&&(r[i]=n[i])}}}return r}});
 
@@ -24,8 +23,8 @@
 
     sixpack.Session = function (options) {
         Object.assign(this, sixpack, options);
-        if(!this.client_id) {
-          this.client_id = this.generate_client_id();
+        if (!this.client_id) {
+            this.client_id = this.generate_client_id();
         }
         if (!on_node) {
             this.user_agent = this.user_agent || (window && window.navigator && window.navigator.userAgent);

--- a/test/sixpack-test.js
+++ b/test/sixpack-test.js
@@ -62,7 +62,7 @@ describe("Sixpack", function () {
 
     it("should return ok for convert", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.participate("show-bieber", ["trolled", "not-trolled"], function(err, resp) {
             if (err) throw err;
             session.convert("show-bieber", function(err, resp) {
@@ -75,7 +75,7 @@ describe("Sixpack", function () {
 
     it("should return ok for multiple converts", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.participate("show-bieber", ["trolled", "not-trolled"], function(err, alt) {
             if (err) throw err;
             session.convert("show-bieber", function(err, resp) {
@@ -92,7 +92,7 @@ describe("Sixpack", function () {
 
     it("should not return ok for convert with new client_id", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("unknown_idizzle")
+        var session = new sixpack.Session({client_id: "unknown_idizzle"})
         session.convert("show-bieber", function(err, resp) {
             if (err) throw err;
             expect(resp.status).to.equal("failed");
@@ -102,7 +102,7 @@ describe("Sixpack", function () {
 
     it("should not return ok for convert with new experiment", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.convert("show-blieber", function(err, resp) {
             // TODO should this be an err?
             if (err) throw err;
@@ -113,7 +113,7 @@ describe("Sixpack", function () {
 
     it("should return ok for convert with kpi", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.convert("show-bieber", "justin-shown", function(err, resp) {
             if (err) throw err;
             expect(resp.status).to.equal("ok");


### PR DESCRIPTION
Some motivation:
Now the order of arguments matters which makes the API a bitt stiff.

Example now you write undefined if you only want to set base_url:
```
sixpack.Session(undefined, 'http://mysixpackserver.com');
```

New API:
```
sixpack.Session({base_url: 'http://mysixpackserver.com'});
```