### PR TITLE
Add option “persist” to make client_id persistent.

### DIFF
--- a/sixpack.js
+++ b/sixpack.js
@@ -42,7 +42,8 @@
 
         if (!this.client_id) {
             if (this.persist && !on_node) {
-                this.client_id = this.persisted_client_id() || this.generate_client_id();
+                var persisted_id = this.persisted_client_id();
+                this.client_id = persisted_id !== null ? persisted_id : this.generate_client_id();
             } else {
                 this.client_id = this.generate_client_id();
             }

--- a/sixpack.js
+++ b/sixpack.js
@@ -2,7 +2,13 @@
     // Object.assign polyfill from https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
     Object.assign||Object.defineProperty(Object,"assign",{enumerable:!1,configurable:!0,writable:!0,value:function(e){"use strict";if(void 0===e||null===e)throw new TypeError("Cannot convert first argument to object");for(var r=Object(e),t=1;t<arguments.length;t++){var n=arguments[t];if(void 0!==n&&null!==n){n=Object(n);for(var o=Object.keys(Object(n)),a=0,c=o.length;c>a;a++){var i=o[a],b=Object.getOwnPropertyDescriptor(n,i);void 0!==b&&b.enumerable&&(r[i]=n[i])}}}return r}});
 
-    var sixpack = {base_url: "http://localhost:5000", ip_address: null, user_agent: null, timeout: 1000};
+    var sixpack = {
+        base_url: "http://localhost:5000",
+        ip_address: null,
+        user_agent: null,
+        timeout: 1000,
+        persist: false
+    };
 
     // check for node module loader
     var on_node = false;
@@ -13,18 +19,31 @@
         window["sixpack"] = sixpack;
     }
 
-    sixpack.generate_client_id = function () {
+    sixpack.generate_client_id = function (persist) {
         // from http://stackoverflow.com/questions/105034
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var client_id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
             var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
             return v.toString(16);
         });
+        if (!on_node && persist) {
+            document.cookie = persist + "=" + client_id + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
+        }
+        return client_id;
     };
+
+    sixpack.get_persisted_client_id = function() {
+      var cookie_regexp = new RegExp("/(?:(?:^|.*;\s*)" + this.persist + "\s*\=\s*([^;]*).*$)|^.*$/"),
+      client_id = document.cookie.replace(cookie_regexp, "$1");
+      if (client_id === "") {
+        return undefined;
+      }
+      return client_id;
+    }
 
     sixpack.Session = function (options) {
         Object.assign(this, sixpack, options);
         if (!this.client_id) {
-            this.client_id = this.generate_client_id();
+            this.client_id = this.generate_client_id(this.persist);
         }
         if (!on_node) {
             this.user_agent = this.user_agent || (window && window.navigator && window.navigator.userAgent);

--- a/sixpack.js
+++ b/sixpack.js
@@ -7,7 +7,7 @@
         ip_address: null,
         user_agent: null,
         timeout: 1000,
-        persist: false
+        persist: true
     };
 
     // check for node module loader
@@ -26,7 +26,7 @@
             return v.toString(16);
         });
         if (!on_node && this.persist) {
-            document.cookie = this.persist + "=" + client_id + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
+            document.cookie = "sixpack_client_id=" + client_id + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
         }
         return client_id;
     };
@@ -34,7 +34,7 @@
     sixpack.persisted_client_id = function() {
         // http://stackoverflow.com/questions/5639346/shortest-function-for-reading-a-cookie-in-javascript
         var result;
-        return (result = new RegExp('(?:^|; )' + encodeURIComponent(this.persist) + '=([^;]*)').exec(document.cookie)) ? (result[1]) : null;
+        return (result = new RegExp('(?:^|; )' + encodeURIComponent('sixpack_client_id') + '=([^;]*)').exec(document.cookie)) ? (result[1]) : null;
     }
 
     sixpack.Session = function (options) {

--- a/sixpack.js
+++ b/sixpack.js
@@ -19,19 +19,19 @@
         window["sixpack"] = sixpack;
     }
 
-    sixpack.generate_client_id = function (persist) {
+    sixpack.generate_client_id = function () {
         // from http://stackoverflow.com/questions/105034
         var client_id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
             var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
             return v.toString(16);
         });
-        if (!on_node && persist) {
-            document.cookie = persist + "=" + client_id + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
+        if (!on_node && this.persist) {
+            document.cookie = this.persist + "=" + client_id + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
         }
         return client_id;
     };
 
-    sixpack.get_persisted_client_id = function() {
+    sixpack.persisted_client_id = function() {
       var cookie_regexp = new RegExp("/(?:(?:^|.*;\s*)" + this.persist + "\s*\=\s*([^;]*).*$)|^.*$/"),
       client_id = document.cookie.replace(cookie_regexp, "$1");
       if (client_id === "") {
@@ -42,8 +42,13 @@
 
     sixpack.Session = function (options) {
         Object.assign(this, sixpack, options);
+
         if (!this.client_id) {
-            this.client_id = this.generate_client_id(this.persist);
+            if (this.persist && !on_node) {
+                this.client_id = this.persisted_client_id() || this.generate_client_id();
+            } else {
+                this.client_id = this.generate_client_id();
+            }
         }
         if (!on_node) {
             this.user_agent = this.user_agent || (window && window.navigator && window.navigator.userAgent);

--- a/test/sixpack-test.js
+++ b/test/sixpack-test.js
@@ -62,7 +62,7 @@ describe("Sixpack", function () {
 
     it("should return ok for convert", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.participate("show-bieber", ["trolled", "not-trolled"], function(err, resp) {
             if (err) throw err;
             session.convert("show-bieber", function(err, resp) {
@@ -75,7 +75,7 @@ describe("Sixpack", function () {
 
     it("should return ok for multiple converts", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.participate("show-bieber", ["trolled", "not-trolled"], function(err, alt) {
             if (err) throw err;
             session.convert("show-bieber", function(err, resp) {
@@ -92,7 +92,7 @@ describe("Sixpack", function () {
 
     it("should not return ok for convert with new client_id", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("unknown_idizzle")
+        var session = new sixpack.Session({client_id: "unknown_idizzle"})
         session.convert("show-bieber", function(err, resp) {
             if (err) throw err;
             expect(resp.status).to.equal("failed");
@@ -102,7 +102,7 @@ describe("Sixpack", function () {
 
     it("should not return ok for convert with new experiment", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.convert("show-blieber", function(err, resp) {
             // TODO should this be an err?
             if (err) throw err;
@@ -113,7 +113,7 @@ describe("Sixpack", function () {
 
     it("should return ok for convert with kpi", function (done) {
         var sixpack = require('../');
-        var session = new sixpack.Session("mike");
+        var session = new sixpack.Session({client_id: "mike"});
         session.convert("show-bieber", "justin-shown", function(err, resp) {
             if (err) throw err;
             expect(resp.status).to.equal("ok");


### PR DESCRIPTION
When “persist” option string is set, client_id is stored in a cookie with this name. On any subsequent sessions the stored client_id is used as long as persist option is set.

By default persist = false.

This feature is useful if you want your users to get the same variation each time and only participate once.