### PR TITLE
update on_node check, fix export for webpack environment

### DIFF
--- a/sixpack.js
+++ b/sixpack.js
@@ -4,11 +4,10 @@
 
     var sixpack = {base_url: "http://localhost:5000", ip_address: null, user_agent: null, timeout: 1000};
 
-    // check for node module loader
+    // check if on node, else expose on browser's global window object
     var on_node = false;
-    if (typeof module !== "undefined" && typeof require !== "undefined") {
+    if (typeof window === "undefined") {
         on_node = true;
-        module.exports = sixpack;
     } else {
         window["sixpack"] = sixpack;
     }
@@ -205,4 +204,9 @@
         }
         return false;
     };
+
+    // export module for node or environments with module loaders, such as webpack
+    if (typeof module !== "undefined" && typeof require !== "undefined") {
+        module.exports = sixpack;
+    }
 })();


### PR DESCRIPTION
This module has some issues in a browser environment with a module loader, such as webpack.

The previous `on_node` check incorrectly returned true in the browser, since webpack overrides and makes available `module` and `require`.

This PR maintains backwards-compatibility by continuing to expose `sixpack` on the global window object in the browser, but updates to support environments with module loaders.